### PR TITLE
README: Correct typo in description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div>
   <h1 align="center"><a href="https://kentcdodds.com/workshops">🔐 Web Authentication</a></h1>
   <strong>
-    Take ownership of you application's authentication and authorization
+    Take ownership of your application's authentication and authorization
   </strong>
   <p>
     In this workshop, we'll learn how to implement authentication and


### PR DESCRIPTION
Towards #4

This PR updates the README to replace `you` with `your` so the copy reads:

> Take ownership of your application's authentication and authorization

This change only affects the README -- what's reported in #4 can only be edited by owners of the `epicweb-dev` org. 😉 