### PR TITLE
fix(docs): README typo on Session Storage page

### DIFF
--- a/exercises/02.session-storage/README.mdx
+++ b/exercises/02.session-storage/README.mdx
@@ -1,6 +1,6 @@
 # Session Storage
 
-Storing user preferences is cookies is simple enough. If you check the developer
+Storing user preferences in cookies is simple enough. If you check the developer
 tools for those, you'll often find the value as-is and can modify it using the
 developer tools (and sometimes even with JavaScript). For user preferences
 that's fine, but when it comes to authentication, we need to be more careful.


### PR DESCRIPTION
Self-explanatory code change, but I spotted what I think is a typo on https://auth.epicweb.dev/02

> Storing user preferences **is** cookies is simple enough.