### PR TITLE
Remove duplicated `null` check

### DIFF
--- a/exercises/07.protecting-routes/04.solution.redirect/app/utils/auth.server.ts
+++ b/exercises/07.protecting-routes/04.solution.redirect/app/utils/auth.server.ts
@@ -38,7 +38,7 @@ export async function requireUserId(
 		redirectTo =
 			redirectTo === null
 				? null
-				: redirectTo ?? `${requestUrl.pathname}${requestUrl.search}`
+				: `${requestUrl.pathname}${requestUrl.search}`
 		const loginParams = redirectTo ? new URLSearchParams({ redirectTo }) : null
 		const loginRedirect = ['/login', loginParams?.toString()]
 			.filter(Boolean)


### PR DESCRIPTION
Looks like we're having a `? null` right above it so there's no need to have an extra `redirectTo ??` there. 
Please correct me if I'm wrong. Thank you.