### PR TITLE
Use code query parameter for zod error path

### DIFF
--- a/exercises/11.verification/01.problem.schema/app/routes/_auth+/verify.tsx
+++ b/exercises/11.verification/01.problem.schema/app/routes/_auth+/verify.tsx
@@ -60,7 +60,7 @@ async function validateRequest(
 				const codeIsValid = true
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/11.verification/01.solution.schema/app/routes/_auth+/verify.tsx
+++ b/exercises/11.verification/01.solution.schema/app/routes/_auth+/verify.tsx
@@ -60,7 +60,7 @@ async function validateRequest(
 				const codeIsValid = true
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/11.verification/02.problem.totp/app/routes/_auth+/verify.tsx
+++ b/exercises/11.verification/02.problem.totp/app/routes/_auth+/verify.tsx
@@ -60,7 +60,7 @@ async function validateRequest(
 				const codeIsValid = true
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/11.verification/02.solution.totp/app/routes/_auth+/verify.tsx
+++ b/exercises/11.verification/02.solution.totp/app/routes/_auth+/verify.tsx
@@ -60,7 +60,7 @@ async function validateRequest(
 				const codeIsValid = true
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/11.verification/03.problem.verify-code/app/routes/_auth+/verify.tsx
+++ b/exercises/11.verification/03.problem.verify-code/app/routes/_auth+/verify.tsx
@@ -70,7 +70,7 @@ async function validateRequest(
 				const codeIsValid = true
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/11.verification/03.solution.verify-code/app/routes/_auth+/verify.tsx
+++ b/exercises/11.verification/03.solution.verify-code/app/routes/_auth+/verify.tsx
@@ -83,7 +83,7 @@ async function validateRequest(
 				})
 				if (!verification) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})
@@ -95,7 +95,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/12.reset-password/01.problem.handle-verification/app/routes/_auth+/verify.tsx
+++ b/exercises/12.reset-password/01.problem.handle-verification/app/routes/_auth+/verify.tsx
@@ -170,7 +170,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/12.reset-password/01.solution.handle-verification/app/routes/_auth+/verify.tsx
+++ b/exercises/12.reset-password/01.solution.handle-verification/app/routes/_auth+/verify.tsx
@@ -170,7 +170,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/12.reset-password/02.problem.reset-password/app/routes/_auth+/verify.tsx
+++ b/exercises/12.reset-password/02.problem.reset-password/app/routes/_auth+/verify.tsx
@@ -170,7 +170,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/12.reset-password/02.solution.reset-password/app/routes/_auth+/verify.tsx
+++ b/exercises/12.reset-password/02.solution.reset-password/app/routes/_auth+/verify.tsx
@@ -170,7 +170,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/13.change-email/01.problem.totp/app/routes/_auth+/verify.tsx
+++ b/exercises/13.change-email/01.problem.totp/app/routes/_auth+/verify.tsx
@@ -171,7 +171,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/13.change-email/01.solution.totp/app/routes/_auth+/verify.tsx
+++ b/exercises/13.change-email/01.solution.totp/app/routes/_auth+/verify.tsx
@@ -171,7 +171,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/13.change-email/02.problem.handle-verification/app/routes/_auth+/verify.tsx
+++ b/exercises/13.change-email/02.problem.handle-verification/app/routes/_auth+/verify.tsx
@@ -171,7 +171,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/13.change-email/02.solution.handle-verification/app/routes/_auth+/verify.tsx
+++ b/exercises/13.change-email/02.solution.handle-verification/app/routes/_auth+/verify.tsx
@@ -171,7 +171,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/14.enable-2fa/01.problem.create/app/routes/_auth+/verify.tsx
+++ b/exercises/14.enable-2fa/01.problem.create/app/routes/_auth+/verify.tsx
@@ -171,7 +171,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/14.enable-2fa/01.solution.create/app/routes/_auth+/verify.tsx
+++ b/exercises/14.enable-2fa/01.solution.create/app/routes/_auth+/verify.tsx
@@ -171,7 +171,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/14.enable-2fa/02.problem.qr-code/app/routes/_auth+/verify.tsx
+++ b/exercises/14.enable-2fa/02.problem.qr-code/app/routes/_auth+/verify.tsx
@@ -171,7 +171,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/14.enable-2fa/02.solution.qr-code/app/routes/_auth+/verify.tsx
+++ b/exercises/14.enable-2fa/02.solution.qr-code/app/routes/_auth+/verify.tsx
@@ -171,7 +171,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/14.enable-2fa/03.problem.verify/app/routes/_auth+/verify.tsx
+++ b/exercises/14.enable-2fa/03.problem.verify/app/routes/_auth+/verify.tsx
@@ -174,7 +174,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/14.enable-2fa/03.solution.verify/app/routes/_auth+/verify.tsx
+++ b/exercises/14.enable-2fa/03.solution.verify/app/routes/_auth+/verify.tsx
@@ -172,7 +172,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/15.verify-2fa/01.problem.unverified/app/routes/_auth+/verify.tsx
+++ b/exercises/15.verify-2fa/01.problem.unverified/app/routes/_auth+/verify.tsx
@@ -173,7 +173,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/15.verify-2fa/01.solution.unverified/app/routes/_auth+/verify.tsx
+++ b/exercises/15.verify-2fa/01.solution.unverified/app/routes/_auth+/verify.tsx
@@ -173,7 +173,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/15.verify-2fa/02.problem.verify/app/routes/_auth+/verify.tsx
+++ b/exercises/15.verify-2fa/02.problem.verify/app/routes/_auth+/verify.tsx
@@ -173,7 +173,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/15.verify-2fa/02.solution.verify/app/routes/_auth+/verify.tsx
+++ b/exercises/15.verify-2fa/02.solution.verify/app/routes/_auth+/verify.tsx
@@ -174,7 +174,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/16.2fa-check/01.problem.delete/app/routes/_auth+/verify.tsx
+++ b/exercises/16.2fa-check/01.problem.delete/app/routes/_auth+/verify.tsx
@@ -174,7 +174,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/16.2fa-check/01.solution.delete/app/routes/_auth+/verify.tsx
+++ b/exercises/16.2fa-check/01.solution.delete/app/routes/_auth+/verify.tsx
@@ -174,7 +174,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/16.2fa-check/02.problem.should-reverify/app/routes/_auth+/verify.tsx
+++ b/exercises/16.2fa-check/02.problem.should-reverify/app/routes/_auth+/verify.tsx
@@ -174,7 +174,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/16.2fa-check/02.solution.should-reverify/app/routes/_auth+/verify.tsx
+++ b/exercises/16.2fa-check/02.solution.should-reverify/app/routes/_auth+/verify.tsx
@@ -174,7 +174,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/16.2fa-check/03.problem.require-reverify/app/routes/_auth+/verify.tsx
+++ b/exercises/16.2fa-check/03.problem.require-reverify/app/routes/_auth+/verify.tsx
@@ -174,7 +174,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/16.2fa-check/03.solution.require-reverify/app/routes/_auth+/verify.tsx
+++ b/exercises/16.2fa-check/03.solution.require-reverify/app/routes/_auth+/verify.tsx
@@ -174,7 +174,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/16.2fa-check/04.problem.expiration/app/routes/_auth+/verify.tsx
+++ b/exercises/16.2fa-check/04.problem.expiration/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/16.2fa-check/04.solution.expiration/app/routes/_auth+/verify.tsx
+++ b/exercises/16.2fa-check/04.solution.expiration/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/17.oauth/01.problem.remix-auth/app/routes/_auth+/verify.tsx
+++ b/exercises/17.oauth/01.problem.remix-auth/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/17.oauth/01.solution.remix-auth/app/routes/_auth+/verify.tsx
+++ b/exercises/17.oauth/01.solution.remix-auth/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/17.oauth/02.problem.flow/app/routes/_auth+/verify.tsx
+++ b/exercises/17.oauth/02.problem.flow/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/17.oauth/02.solution.flow/app/routes/_auth+/verify.tsx
+++ b/exercises/17.oauth/02.solution.flow/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/17.oauth/03.problem.mock/app/routes/_auth+/verify.tsx
+++ b/exercises/17.oauth/03.problem.mock/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/17.oauth/03.solution.mock/app/routes/_auth+/verify.tsx
+++ b/exercises/17.oauth/03.solution.mock/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/17.oauth/04.problem.schema/app/routes/_auth+/verify.tsx
+++ b/exercises/17.oauth/04.problem.schema/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/17.oauth/04.solution.schema/app/routes/_auth+/verify.tsx
+++ b/exercises/17.oauth/04.solution.schema/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/18.provider-errors/01.problem.auth-error/app/routes/_auth+/verify.tsx
+++ b/exercises/18.provider-errors/01.problem.auth-error/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/18.provider-errors/01.solution.auth-error/app/routes/_auth+/verify.tsx
+++ b/exercises/18.provider-errors/01.solution.auth-error/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/18.provider-errors/02.problem.connection-error/app/routes/_auth+/verify.tsx
+++ b/exercises/18.provider-errors/02.problem.connection-error/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/18.provider-errors/02.solution.connection-error/app/routes/_auth+/verify.tsx
+++ b/exercises/18.provider-errors/02.solution.connection-error/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/19.third-party-login/01.problem.login/app/routes/_auth+/verify.tsx
+++ b/exercises/19.third-party-login/01.problem.login/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/19.third-party-login/01.solution.login/app/routes/_auth+/verify.tsx
+++ b/exercises/19.third-party-login/01.solution.login/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/19.third-party-login/02.problem.onboarding/app/routes/_auth+/verify.tsx
+++ b/exercises/19.third-party-login/02.problem.onboarding/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/19.third-party-login/02.solution.onboarding/app/routes/_auth+/verify.tsx
+++ b/exercises/19.third-party-login/02.solution.onboarding/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/20.connection/01.problem.existing-user/app/routes/_auth+/verify.tsx
+++ b/exercises/20.connection/01.problem.existing-user/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/20.connection/01.solution.existing-user/app/routes/_auth+/verify.tsx
+++ b/exercises/20.connection/01.solution.existing-user/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/20.connection/02.problem.connect/app/routes/_auth+/verify.tsx
+++ b/exercises/20.connection/02.problem.connect/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/20.connection/02.solution.connect/app/routes/_auth+/verify.tsx
+++ b/exercises/20.connection/02.solution.connect/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/21.redirect-cookie/01.problem.pass/app/routes/_auth+/verify.tsx
+++ b/exercises/21.redirect-cookie/01.problem.pass/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/21.redirect-cookie/01.solution.pass/app/routes/_auth+/verify.tsx
+++ b/exercises/21.redirect-cookie/01.solution.pass/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/21.redirect-cookie/02.problem.cookie/app/routes/_auth+/verify.tsx
+++ b/exercises/21.redirect-cookie/02.problem.cookie/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/21.redirect-cookie/02.solution.cookie/app/routes/_auth+/verify.tsx
+++ b/exercises/21.redirect-cookie/02.solution.cookie/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/21.redirect-cookie/03.problem.redirect/app/routes/_auth+/verify.tsx
+++ b/exercises/21.redirect-cookie/03.problem.redirect/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})

--- a/exercises/21.redirect-cookie/03.solution.redirect/app/routes/_auth+/verify.tsx
+++ b/exercises/21.redirect-cookie/03.solution.redirect/app/routes/_auth+/verify.tsx
@@ -201,7 +201,7 @@ async function validateRequest(
 				})
 				if (!codeIsValid) {
 					ctx.addIssue({
-						path: ['code'],
+						path: [codeQueryParam],
 						code: z.ZodIssueCode.custom,
 						message: `Invalid code`,
 					})


### PR DESCRIPTION
Hey Kent,

I like the concept of the configurable parameter names. However, 'codeQueryParam' should be used for the zod error path as well. This helps prevent errors in case the string  in 'codeQueryParam' is modified later.

Regards,
Jörn