### PR TITLE
Add the instruction to move to correct folder

### DIFF
--- a/exercises/04.password/01.problem.schema/README.mdx
+++ b/exercises/04.password/01.problem.schema/README.mdx
@@ -29,7 +29,7 @@ more information).
 npx prisma migrate dev --name password
 ```
 
-💰 you might want to ```cd``` into the ```playground``` folder to execute above command
+<callout-warning>make sure to run this in the `playground` directory</callout-warning>
 
 That should get you set up with a migration for adding the password to the
 database and ready for the next step.

--- a/exercises/04.password/01.problem.schema/README.mdx
+++ b/exercises/04.password/01.problem.schema/README.mdx
@@ -29,5 +29,7 @@ more information).
 npx prisma migrate dev --name password
 ```
 
+💰 you might want to ```cd``` into the ```playground``` folder to execute above command
+
 That should get you set up with a migration for adding the password to the
 database and ready for the next step.


### PR DESCRIPTION
Some users might just try to run the command for the same folder as they have run the npm run dev, which will not work for sure, so this change will let them realise the the correct folder is one step down.