### PR TITLE
Png file extension issue

### DIFF
--- a/exercises/01.cookies/01.problem.fetcher/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/01.cookies/01.problem.fetcher/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/01.cookies/01.problem.fetcher/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/01.cookies/01.problem.fetcher/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/01.cookies/01.problem.fetcher/app/utils/misc.tsx
+++ b/exercises/01.cookies/01.problem.fetcher/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/01.cookies/01.solution.fetcher/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/01.cookies/01.solution.fetcher/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/01.cookies/01.solution.fetcher/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/01.cookies/01.solution.fetcher/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/01.cookies/01.solution.fetcher/app/utils/misc.tsx
+++ b/exercises/01.cookies/01.solution.fetcher/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/01.cookies/02.problem.theme/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/01.cookies/02.problem.theme/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/01.cookies/02.problem.theme/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/01.cookies/02.problem.theme/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/01.cookies/02.problem.theme/app/utils/misc.tsx
+++ b/exercises/01.cookies/02.problem.theme/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/01.cookies/02.solution.theme/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/01.cookies/02.solution.theme/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/01.cookies/02.solution.theme/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/01.cookies/02.solution.theme/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/01.cookies/02.solution.theme/app/utils/misc.tsx
+++ b/exercises/01.cookies/02.solution.theme/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/01.cookies/03.problem.optimistic-theme/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/01.cookies/03.problem.optimistic-theme/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/01.cookies/03.problem.optimistic-theme/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/01.cookies/03.problem.optimistic-theme/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/01.cookies/03.problem.optimistic-theme/app/utils/misc.tsx
+++ b/exercises/01.cookies/03.problem.optimistic-theme/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/01.cookies/03.solution.optimistic-theme/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/01.cookies/03.solution.optimistic-theme/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/01.cookies/03.solution.optimistic-theme/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/01.cookies/03.solution.optimistic-theme/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/01.cookies/03.solution.optimistic-theme/app/utils/misc.tsx
+++ b/exercises/01.cookies/03.solution.optimistic-theme/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/02.session-storage/01.problem.session/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/02.session-storage/01.problem.session/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/02.session-storage/01.problem.session/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/02.session-storage/01.problem.session/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/02.session-storage/01.problem.session/app/utils/misc.tsx
+++ b/exercises/02.session-storage/01.problem.session/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/02.session-storage/01.solution.session/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/02.session-storage/01.solution.session/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/02.session-storage/01.solution.session/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/02.session-storage/01.solution.session/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/02.session-storage/01.solution.session/app/utils/misc.tsx
+++ b/exercises/02.session-storage/01.solution.session/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/02.session-storage/02.problem.set/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/02.session-storage/02.problem.set/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/02.session-storage/02.problem.set/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/02.session-storage/02.problem.set/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/02.session-storage/02.problem.set/app/utils/misc.tsx
+++ b/exercises/02.session-storage/02.problem.set/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/02.session-storage/02.solution.set/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/02.session-storage/02.solution.set/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/02.session-storage/02.solution.set/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/02.session-storage/02.solution.set/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/02.session-storage/02.solution.set/app/utils/misc.tsx
+++ b/exercises/02.session-storage/02.solution.set/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/02.session-storage/03.problem.unset/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/02.session-storage/03.problem.unset/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/02.session-storage/03.problem.unset/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/02.session-storage/03.problem.unset/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/02.session-storage/03.problem.unset/app/utils/misc.tsx
+++ b/exercises/02.session-storage/03.problem.unset/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/02.session-storage/03.solution.unset/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/02.session-storage/03.solution.unset/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/02.session-storage/03.solution.unset/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/02.session-storage/03.solution.unset/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/02.session-storage/03.solution.unset/app/utils/misc.tsx
+++ b/exercises/02.session-storage/03.solution.unset/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/02.session-storage/04.problem.flash/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/02.session-storage/04.problem.flash/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/02.session-storage/04.problem.flash/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/02.session-storage/04.problem.flash/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/02.session-storage/04.problem.flash/app/utils/misc.tsx
+++ b/exercises/02.session-storage/04.problem.flash/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/02.session-storage/04.solution.flash/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/02.session-storage/04.solution.flash/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/02.session-storage/04.solution.flash/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/02.session-storage/04.solution.flash/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/02.session-storage/04.solution.flash/app/utils/misc.tsx
+++ b/exercises/02.session-storage/04.solution.flash/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/03.user-sessions/01.problem.session/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/03.user-sessions/01.problem.session/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/03.user-sessions/01.problem.session/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/03.user-sessions/01.problem.session/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/03.user-sessions/01.problem.session/app/utils/misc.tsx
+++ b/exercises/03.user-sessions/01.problem.session/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/03.user-sessions/01.solution.session/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/03.user-sessions/01.solution.session/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/03.user-sessions/01.solution.session/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/03.user-sessions/01.solution.session/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/03.user-sessions/01.solution.session/app/utils/misc.tsx
+++ b/exercises/03.user-sessions/01.solution.session/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/03.user-sessions/02.problem.login/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/03.user-sessions/02.problem.login/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/03.user-sessions/02.problem.login/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/03.user-sessions/02.problem.login/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/03.user-sessions/02.problem.login/app/utils/misc.tsx
+++ b/exercises/03.user-sessions/02.problem.login/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/03.user-sessions/02.solution.login/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/03.user-sessions/02.solution.login/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/03.user-sessions/02.solution.login/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/03.user-sessions/02.solution.login/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/03.user-sessions/02.solution.login/app/utils/misc.tsx
+++ b/exercises/03.user-sessions/02.solution.login/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/03.user-sessions/03.problem.root/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/03.user-sessions/03.problem.root/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/03.user-sessions/03.problem.root/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/03.user-sessions/03.problem.root/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/03.user-sessions/03.problem.root/app/utils/misc.tsx
+++ b/exercises/03.user-sessions/03.problem.root/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/03.user-sessions/03.solution.root/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/03.user-sessions/03.solution.root/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/03.user-sessions/03.solution.root/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/03.user-sessions/03.solution.root/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/03.user-sessions/03.solution.root/app/utils/misc.tsx
+++ b/exercises/03.user-sessions/03.solution.root/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/04.password/01.problem.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/04.password/01.problem.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/04.password/01.problem.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/04.password/01.problem.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/04.password/01.problem.schema/app/utils/misc.tsx
+++ b/exercises/04.password/01.problem.schema/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/04.password/01.solution.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/04.password/01.solution.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/04.password/01.solution.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/04.password/01.solution.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/04.password/01.solution.schema/app/utils/misc.tsx
+++ b/exercises/04.password/01.solution.schema/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/04.password/02.problem.seed/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/04.password/02.problem.seed/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/04.password/02.problem.seed/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/04.password/02.problem.seed/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/04.password/02.problem.seed/app/utils/misc.tsx
+++ b/exercises/04.password/02.problem.seed/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/04.password/02.solution.seed/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/04.password/02.solution.seed/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/04.password/02.solution.seed/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/04.password/02.solution.seed/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/04.password/02.solution.seed/app/utils/misc.tsx
+++ b/exercises/04.password/02.solution.seed/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/04.password/03.problem.signup/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/04.password/03.problem.signup/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/04.password/03.problem.signup/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/04.password/03.problem.signup/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/04.password/03.problem.signup/app/utils/misc.tsx
+++ b/exercises/04.password/03.problem.signup/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/04.password/03.solution.signup/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/04.password/03.solution.signup/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/04.password/03.solution.signup/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/04.password/03.solution.signup/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/04.password/03.solution.signup/app/utils/misc.tsx
+++ b/exercises/04.password/03.solution.signup/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/05.login/01.problem.login/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/05.login/01.problem.login/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/05.login/01.problem.login/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/05.login/01.problem.login/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/05.login/01.problem.login/app/utils/misc.tsx
+++ b/exercises/05.login/01.problem.login/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/05.login/01.solution.login/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/05.login/01.solution.login/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/05.login/01.solution.login/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/05.login/01.solution.login/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/05.login/01.solution.login/app/utils/misc.tsx
+++ b/exercises/05.login/01.solution.login/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/05.login/02.problem.ui-utils/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/05.login/02.problem.ui-utils/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/05.login/02.problem.ui-utils/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/05.login/02.problem.ui-utils/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/05.login/02.problem.ui-utils/app/utils/misc.tsx
+++ b/exercises/05.login/02.problem.ui-utils/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/05.login/02.solution.ui-utils/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/05.login/02.solution.ui-utils/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/05.login/02.solution.ui-utils/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/05.login/02.solution.ui-utils/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/05.login/02.solution.ui-utils/app/utils/misc.tsx
+++ b/exercises/05.login/02.solution.ui-utils/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/06.logout/01.problem.logout/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/06.logout/01.problem.logout/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/06.logout/01.problem.logout/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/06.logout/01.problem.logout/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/06.logout/01.problem.logout/app/utils/misc.tsx
+++ b/exercises/06.logout/01.problem.logout/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/06.logout/01.solution.logout/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/06.logout/01.solution.logout/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/06.logout/01.solution.logout/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/06.logout/01.solution.logout/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/06.logout/01.solution.logout/app/utils/misc.tsx
+++ b/exercises/06.logout/01.solution.logout/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/06.logout/02.problem.expiration/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/06.logout/02.problem.expiration/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/06.logout/02.problem.expiration/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/06.logout/02.problem.expiration/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/06.logout/02.problem.expiration/app/utils/misc.tsx
+++ b/exercises/06.logout/02.problem.expiration/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/06.logout/02.solution.expiration/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/06.logout/02.solution.expiration/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/06.logout/02.solution.expiration/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/06.logout/02.solution.expiration/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/06.logout/02.solution.expiration/app/utils/misc.tsx
+++ b/exercises/06.logout/02.solution.expiration/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/06.logout/03.problem.deleted/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/06.logout/03.problem.deleted/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/06.logout/03.problem.deleted/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/06.logout/03.problem.deleted/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/06.logout/03.problem.deleted/app/utils/misc.tsx
+++ b/exercises/06.logout/03.problem.deleted/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/06.logout/03.solution.deleted/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/06.logout/03.solution.deleted/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/06.logout/03.solution.deleted/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/06.logout/03.solution.deleted/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/06.logout/03.solution.deleted/app/utils/misc.tsx
+++ b/exercises/06.logout/03.solution.deleted/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/06.logout/04.problem.auto-logout/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/06.logout/04.problem.auto-logout/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/06.logout/04.problem.auto-logout/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/06.logout/04.problem.auto-logout/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/06.logout/04.problem.auto-logout/app/utils/misc.tsx
+++ b/exercises/06.logout/04.problem.auto-logout/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/06.logout/04.solution.auto-logout/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/06.logout/04.solution.auto-logout/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/06.logout/04.solution.auto-logout/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/06.logout/04.solution.auto-logout/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/06.logout/04.solution.auto-logout/app/utils/misc.tsx
+++ b/exercises/06.logout/04.solution.auto-logout/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/07.protecting-routes/01.problem.anonymous/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/07.protecting-routes/01.problem.anonymous/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/07.protecting-routes/01.problem.anonymous/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/07.protecting-routes/01.problem.anonymous/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/07.protecting-routes/01.problem.anonymous/app/utils/misc.tsx
+++ b/exercises/07.protecting-routes/01.problem.anonymous/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/07.protecting-routes/01.solution.anonymous/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/07.protecting-routes/01.solution.anonymous/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/07.protecting-routes/01.solution.anonymous/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/07.protecting-routes/01.solution.anonymous/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/07.protecting-routes/01.solution.anonymous/app/utils/misc.tsx
+++ b/exercises/07.protecting-routes/01.solution.anonymous/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/07.protecting-routes/02.problem.authenticated/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/07.protecting-routes/02.problem.authenticated/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/07.protecting-routes/02.problem.authenticated/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/07.protecting-routes/02.problem.authenticated/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/07.protecting-routes/02.problem.authenticated/app/utils/misc.tsx
+++ b/exercises/07.protecting-routes/02.problem.authenticated/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/07.protecting-routes/02.solution.authenticated/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/07.protecting-routes/02.solution.authenticated/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/07.protecting-routes/02.solution.authenticated/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/07.protecting-routes/02.solution.authenticated/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/07.protecting-routes/02.solution.authenticated/app/utils/misc.tsx
+++ b/exercises/07.protecting-routes/02.solution.authenticated/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/07.protecting-routes/03.problem.authorized/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/07.protecting-routes/03.problem.authorized/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/07.protecting-routes/03.problem.authorized/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/07.protecting-routes/03.problem.authorized/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/07.protecting-routes/03.problem.authorized/app/utils/misc.tsx
+++ b/exercises/07.protecting-routes/03.problem.authorized/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/07.protecting-routes/03.solution.authorized/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/07.protecting-routes/03.solution.authorized/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/07.protecting-routes/03.solution.authorized/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/07.protecting-routes/03.solution.authorized/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/07.protecting-routes/03.solution.authorized/app/utils/misc.tsx
+++ b/exercises/07.protecting-routes/03.solution.authorized/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/07.protecting-routes/04.problem.redirect/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/07.protecting-routes/04.problem.redirect/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/07.protecting-routes/04.problem.redirect/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/07.protecting-routes/04.problem.redirect/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/07.protecting-routes/04.problem.redirect/app/utils/misc.tsx
+++ b/exercises/07.protecting-routes/04.problem.redirect/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/07.protecting-routes/04.solution.redirect/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/07.protecting-routes/04.solution.redirect/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/07.protecting-routes/04.solution.redirect/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/07.protecting-routes/04.solution.redirect/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/07.protecting-routes/04.solution.redirect/app/utils/misc.tsx
+++ b/exercises/07.protecting-routes/04.solution.redirect/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/08.permissions/01.problem.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/08.permissions/01.problem.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/08.permissions/01.problem.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/08.permissions/01.problem.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/08.permissions/01.problem.schema/app/utils/misc.tsx
+++ b/exercises/08.permissions/01.problem.schema/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/08.permissions/01.solution.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/08.permissions/01.solution.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/08.permissions/01.solution.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/08.permissions/01.solution.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/08.permissions/01.solution.schema/app/utils/misc.tsx
+++ b/exercises/08.permissions/01.solution.schema/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/08.permissions/02.problem.seed/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/08.permissions/02.problem.seed/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/08.permissions/02.problem.seed/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/08.permissions/02.problem.seed/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/08.permissions/02.problem.seed/app/utils/misc.tsx
+++ b/exercises/08.permissions/02.problem.seed/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/08.permissions/02.solution.seed/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/08.permissions/02.solution.seed/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/08.permissions/02.solution.seed/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/08.permissions/02.solution.seed/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/08.permissions/02.solution.seed/app/utils/misc.tsx
+++ b/exercises/08.permissions/02.solution.seed/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/08.permissions/03.problem.delete-note/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/08.permissions/03.problem.delete-note/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/08.permissions/03.problem.delete-note/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/08.permissions/03.problem.delete-note/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/08.permissions/03.problem.delete-note/app/utils/misc.tsx
+++ b/exercises/08.permissions/03.problem.delete-note/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/08.permissions/03.solution.delete-note/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/08.permissions/03.solution.delete-note/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/08.permissions/03.solution.delete-note/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/08.permissions/03.solution.delete-note/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/08.permissions/03.solution.delete-note/app/utils/misc.tsx
+++ b/exercises/08.permissions/03.solution.delete-note/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/08.permissions/04.problem.utils/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/08.permissions/04.problem.utils/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/08.permissions/04.problem.utils/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/08.permissions/04.problem.utils/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/08.permissions/04.problem.utils/app/utils/misc.tsx
+++ b/exercises/08.permissions/04.problem.utils/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/08.permissions/04.solution.utils/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/08.permissions/04.solution.utils/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/08.permissions/04.solution.utils/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/08.permissions/04.solution.utils/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/08.permissions/04.solution.utils/app/utils/misc.tsx
+++ b/exercises/08.permissions/04.solution.utils/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/09.managed-sessions/01.problem.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/09.managed-sessions/01.problem.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/09.managed-sessions/01.problem.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/09.managed-sessions/01.problem.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/09.managed-sessions/01.problem.schema/app/utils/misc.tsx
+++ b/exercises/09.managed-sessions/01.problem.schema/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/09.managed-sessions/01.solution.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/09.managed-sessions/01.solution.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/09.managed-sessions/01.solution.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/09.managed-sessions/01.solution.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/09.managed-sessions/01.solution.schema/app/utils/misc.tsx
+++ b/exercises/09.managed-sessions/01.solution.schema/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/09.managed-sessions/02.problem.auth-utils/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/09.managed-sessions/02.problem.auth-utils/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/09.managed-sessions/02.problem.auth-utils/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/09.managed-sessions/02.problem.auth-utils/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/09.managed-sessions/02.problem.auth-utils/app/utils/misc.tsx
+++ b/exercises/09.managed-sessions/02.problem.auth-utils/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/09.managed-sessions/02.solution.auth-utils/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/09.managed-sessions/02.solution.auth-utils/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/09.managed-sessions/02.solution.auth-utils/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/09.managed-sessions/02.solution.auth-utils/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/09.managed-sessions/02.solution.auth-utils/app/utils/misc.tsx
+++ b/exercises/09.managed-sessions/02.solution.auth-utils/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/09.managed-sessions/03.problem.session-cookie/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/09.managed-sessions/03.problem.session-cookie/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/09.managed-sessions/03.problem.session-cookie/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/09.managed-sessions/03.problem.session-cookie/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/09.managed-sessions/03.problem.session-cookie/app/utils/misc.tsx
+++ b/exercises/09.managed-sessions/03.problem.session-cookie/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/09.managed-sessions/03.solution.session-cookie/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/09.managed-sessions/03.solution.session-cookie/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/09.managed-sessions/03.solution.session-cookie/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/09.managed-sessions/03.solution.session-cookie/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/09.managed-sessions/03.solution.session-cookie/app/utils/misc.tsx
+++ b/exercises/09.managed-sessions/03.solution.session-cookie/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/09.managed-sessions/04.problem.delete-sessions/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/09.managed-sessions/04.problem.delete-sessions/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/09.managed-sessions/04.problem.delete-sessions/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/09.managed-sessions/04.problem.delete-sessions/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/09.managed-sessions/04.problem.delete-sessions/app/utils/misc.tsx
+++ b/exercises/09.managed-sessions/04.problem.delete-sessions/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/09.managed-sessions/04.solution.delete-sessions/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/09.managed-sessions/04.solution.delete-sessions/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/09.managed-sessions/04.solution.delete-sessions/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/09.managed-sessions/04.solution.delete-sessions/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/09.managed-sessions/04.solution.delete-sessions/app/utils/misc.tsx
+++ b/exercises/09.managed-sessions/04.solution.delete-sessions/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/10.email/01.problem.resend/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/10.email/01.problem.resend/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/10.email/01.problem.resend/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/10.email/01.problem.resend/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/10.email/01.problem.resend/app/utils/misc.tsx
+++ b/exercises/10.email/01.problem.resend/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/10.email/01.solution.resend/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/10.email/01.solution.resend/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/10.email/01.solution.resend/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/10.email/01.solution.resend/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/10.email/01.solution.resend/app/utils/misc.tsx
+++ b/exercises/10.email/01.solution.resend/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/10.email/02.problem.mocks/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/10.email/02.problem.mocks/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/10.email/02.problem.mocks/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/10.email/02.problem.mocks/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/10.email/02.problem.mocks/app/utils/misc.tsx
+++ b/exercises/10.email/02.problem.mocks/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/10.email/02.solution.mocks/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/10.email/02.solution.mocks/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/10.email/02.solution.mocks/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/10.email/02.solution.mocks/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/10.email/02.solution.mocks/app/utils/misc.tsx
+++ b/exercises/10.email/02.solution.mocks/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/10.email/03.problem.send/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/10.email/03.problem.send/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/10.email/03.problem.send/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/10.email/03.problem.send/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/10.email/03.problem.send/app/utils/misc.tsx
+++ b/exercises/10.email/03.problem.send/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/10.email/03.solution.send/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/10.email/03.solution.send/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/10.email/03.solution.send/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/10.email/03.solution.send/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/10.email/03.solution.send/app/utils/misc.tsx
+++ b/exercises/10.email/03.solution.send/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/10.email/04.problem.session/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/10.email/04.problem.session/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/10.email/04.problem.session/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/10.email/04.problem.session/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/10.email/04.problem.session/app/utils/misc.tsx
+++ b/exercises/10.email/04.problem.session/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/10.email/04.solution.session/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/10.email/04.solution.session/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/10.email/04.solution.session/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/10.email/04.solution.session/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/10.email/04.solution.session/app/utils/misc.tsx
+++ b/exercises/10.email/04.solution.session/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/11.verification/01.problem.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/11.verification/01.problem.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/11.verification/01.problem.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/11.verification/01.problem.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/11.verification/01.problem.schema/app/utils/misc.tsx
+++ b/exercises/11.verification/01.problem.schema/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/11.verification/01.solution.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/11.verification/01.solution.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/11.verification/01.solution.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/11.verification/01.solution.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/11.verification/01.solution.schema/app/utils/misc.tsx
+++ b/exercises/11.verification/01.solution.schema/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/11.verification/02.problem.totp/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/11.verification/02.problem.totp/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/11.verification/02.problem.totp/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/11.verification/02.problem.totp/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/11.verification/02.problem.totp/app/utils/misc.tsx
+++ b/exercises/11.verification/02.problem.totp/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/11.verification/02.solution.totp/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/11.verification/02.solution.totp/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/11.verification/02.solution.totp/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/11.verification/02.solution.totp/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/11.verification/02.solution.totp/app/utils/misc.tsx
+++ b/exercises/11.verification/02.solution.totp/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/11.verification/03.problem.verify-code/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/11.verification/03.problem.verify-code/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/11.verification/03.problem.verify-code/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/11.verification/03.problem.verify-code/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/11.verification/03.problem.verify-code/app/utils/misc.tsx
+++ b/exercises/11.verification/03.problem.verify-code/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/11.verification/03.solution.verify-code/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/11.verification/03.solution.verify-code/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/11.verification/03.solution.verify-code/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/11.verification/03.solution.verify-code/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/11.verification/03.solution.verify-code/app/utils/misc.tsx
+++ b/exercises/11.verification/03.solution.verify-code/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/12.reset-password/01.problem.handle-verification/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/12.reset-password/01.problem.handle-verification/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/12.reset-password/01.problem.handle-verification/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/12.reset-password/01.problem.handle-verification/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/12.reset-password/01.problem.handle-verification/app/utils/misc.tsx
+++ b/exercises/12.reset-password/01.problem.handle-verification/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/12.reset-password/01.solution.handle-verification/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/12.reset-password/01.solution.handle-verification/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/12.reset-password/01.solution.handle-verification/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/12.reset-password/01.solution.handle-verification/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/12.reset-password/01.solution.handle-verification/app/utils/misc.tsx
+++ b/exercises/12.reset-password/01.solution.handle-verification/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/12.reset-password/02.problem.reset-password/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/12.reset-password/02.problem.reset-password/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/12.reset-password/02.problem.reset-password/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/12.reset-password/02.problem.reset-password/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/12.reset-password/02.problem.reset-password/app/utils/misc.tsx
+++ b/exercises/12.reset-password/02.problem.reset-password/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/12.reset-password/02.solution.reset-password/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/12.reset-password/02.solution.reset-password/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/12.reset-password/02.solution.reset-password/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/12.reset-password/02.solution.reset-password/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/12.reset-password/02.solution.reset-password/app/utils/misc.tsx
+++ b/exercises/12.reset-password/02.solution.reset-password/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/13.change-email/01.problem.totp/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/13.change-email/01.problem.totp/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/13.change-email/01.problem.totp/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/13.change-email/01.problem.totp/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/13.change-email/01.problem.totp/app/utils/misc.tsx
+++ b/exercises/13.change-email/01.problem.totp/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/13.change-email/01.solution.totp/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/13.change-email/01.solution.totp/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/13.change-email/01.solution.totp/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/13.change-email/01.solution.totp/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/13.change-email/01.solution.totp/app/utils/misc.tsx
+++ b/exercises/13.change-email/01.solution.totp/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/13.change-email/02.problem.handle-verification/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/13.change-email/02.problem.handle-verification/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/13.change-email/02.problem.handle-verification/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/13.change-email/02.problem.handle-verification/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/13.change-email/02.problem.handle-verification/app/utils/misc.tsx
+++ b/exercises/13.change-email/02.problem.handle-verification/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/13.change-email/02.solution.handle-verification/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/13.change-email/02.solution.handle-verification/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/13.change-email/02.solution.handle-verification/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/13.change-email/02.solution.handle-verification/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/13.change-email/02.solution.handle-verification/app/utils/misc.tsx
+++ b/exercises/13.change-email/02.solution.handle-verification/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/14.enable-2fa/01.problem.create/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/14.enable-2fa/01.problem.create/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/14.enable-2fa/01.problem.create/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/14.enable-2fa/01.problem.create/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/14.enable-2fa/01.problem.create/app/utils/misc.tsx
+++ b/exercises/14.enable-2fa/01.problem.create/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/14.enable-2fa/01.solution.create/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/14.enable-2fa/01.solution.create/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/14.enable-2fa/01.solution.create/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/14.enable-2fa/01.solution.create/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/14.enable-2fa/01.solution.create/app/utils/misc.tsx
+++ b/exercises/14.enable-2fa/01.solution.create/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/14.enable-2fa/02.problem.qr-code/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/14.enable-2fa/02.problem.qr-code/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/14.enable-2fa/02.problem.qr-code/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/14.enable-2fa/02.problem.qr-code/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/14.enable-2fa/02.problem.qr-code/app/utils/misc.tsx
+++ b/exercises/14.enable-2fa/02.problem.qr-code/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/14.enable-2fa/02.solution.qr-code/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/14.enable-2fa/02.solution.qr-code/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/14.enable-2fa/02.solution.qr-code/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/14.enable-2fa/02.solution.qr-code/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/14.enable-2fa/02.solution.qr-code/app/utils/misc.tsx
+++ b/exercises/14.enable-2fa/02.solution.qr-code/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/14.enable-2fa/03.problem.verify/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/14.enable-2fa/03.problem.verify/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/14.enable-2fa/03.problem.verify/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/14.enable-2fa/03.problem.verify/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/14.enable-2fa/03.problem.verify/app/utils/misc.tsx
+++ b/exercises/14.enable-2fa/03.problem.verify/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/14.enable-2fa/03.solution.verify/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/14.enable-2fa/03.solution.verify/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/14.enable-2fa/03.solution.verify/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/14.enable-2fa/03.solution.verify/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/14.enable-2fa/03.solution.verify/app/utils/misc.tsx
+++ b/exercises/14.enable-2fa/03.solution.verify/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/15.verify-2fa/01.problem.unverified/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/15.verify-2fa/01.problem.unverified/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/15.verify-2fa/01.problem.unverified/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/15.verify-2fa/01.problem.unverified/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/15.verify-2fa/01.problem.unverified/app/utils/misc.tsx
+++ b/exercises/15.verify-2fa/01.problem.unverified/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/15.verify-2fa/01.solution.unverified/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/15.verify-2fa/01.solution.unverified/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/15.verify-2fa/01.solution.unverified/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/15.verify-2fa/01.solution.unverified/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/15.verify-2fa/01.solution.unverified/app/utils/misc.tsx
+++ b/exercises/15.verify-2fa/01.solution.unverified/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/15.verify-2fa/02.problem.verify/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/15.verify-2fa/02.problem.verify/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/15.verify-2fa/02.problem.verify/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/15.verify-2fa/02.problem.verify/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/15.verify-2fa/02.problem.verify/app/utils/misc.tsx
+++ b/exercises/15.verify-2fa/02.problem.verify/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/15.verify-2fa/02.solution.verify/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/15.verify-2fa/02.solution.verify/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/15.verify-2fa/02.solution.verify/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/15.verify-2fa/02.solution.verify/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/15.verify-2fa/02.solution.verify/app/utils/misc.tsx
+++ b/exercises/15.verify-2fa/02.solution.verify/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/16.2fa-check/01.problem.delete/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/16.2fa-check/01.problem.delete/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/16.2fa-check/01.problem.delete/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/16.2fa-check/01.problem.delete/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/16.2fa-check/01.problem.delete/app/utils/misc.tsx
+++ b/exercises/16.2fa-check/01.problem.delete/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/16.2fa-check/01.solution.delete/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/16.2fa-check/01.solution.delete/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/16.2fa-check/01.solution.delete/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/16.2fa-check/01.solution.delete/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/16.2fa-check/01.solution.delete/app/utils/misc.tsx
+++ b/exercises/16.2fa-check/01.solution.delete/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/16.2fa-check/02.problem.should-reverify/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/16.2fa-check/02.problem.should-reverify/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/16.2fa-check/02.problem.should-reverify/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/16.2fa-check/02.problem.should-reverify/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/16.2fa-check/02.problem.should-reverify/app/utils/misc.tsx
+++ b/exercises/16.2fa-check/02.problem.should-reverify/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/16.2fa-check/02.solution.should-reverify/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/16.2fa-check/02.solution.should-reverify/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/16.2fa-check/02.solution.should-reverify/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/16.2fa-check/02.solution.should-reverify/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/16.2fa-check/02.solution.should-reverify/app/utils/misc.tsx
+++ b/exercises/16.2fa-check/02.solution.should-reverify/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/16.2fa-check/03.problem.require-reverify/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/16.2fa-check/03.problem.require-reverify/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/16.2fa-check/03.problem.require-reverify/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/16.2fa-check/03.problem.require-reverify/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/16.2fa-check/03.problem.require-reverify/app/utils/misc.tsx
+++ b/exercises/16.2fa-check/03.problem.require-reverify/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/16.2fa-check/03.solution.require-reverify/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/16.2fa-check/03.solution.require-reverify/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/16.2fa-check/03.solution.require-reverify/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/16.2fa-check/03.solution.require-reverify/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/16.2fa-check/03.solution.require-reverify/app/utils/misc.tsx
+++ b/exercises/16.2fa-check/03.solution.require-reverify/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/16.2fa-check/04.problem.expiration/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/16.2fa-check/04.problem.expiration/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/16.2fa-check/04.problem.expiration/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/16.2fa-check/04.problem.expiration/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/16.2fa-check/04.problem.expiration/app/utils/misc.tsx
+++ b/exercises/16.2fa-check/04.problem.expiration/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/16.2fa-check/04.solution.expiration/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/16.2fa-check/04.solution.expiration/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/16.2fa-check/04.solution.expiration/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/16.2fa-check/04.solution.expiration/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/16.2fa-check/04.solution.expiration/app/utils/misc.tsx
+++ b/exercises/16.2fa-check/04.solution.expiration/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/17.oauth/01.problem.remix-auth/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/17.oauth/01.problem.remix-auth/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/17.oauth/01.problem.remix-auth/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/17.oauth/01.problem.remix-auth/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/17.oauth/01.problem.remix-auth/app/utils/misc.tsx
+++ b/exercises/17.oauth/01.problem.remix-auth/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/17.oauth/01.solution.remix-auth/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/17.oauth/01.solution.remix-auth/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/17.oauth/01.solution.remix-auth/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/17.oauth/01.solution.remix-auth/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/17.oauth/01.solution.remix-auth/app/utils/misc.tsx
+++ b/exercises/17.oauth/01.solution.remix-auth/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/17.oauth/02.problem.flow/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/17.oauth/02.problem.flow/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/17.oauth/02.problem.flow/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/17.oauth/02.problem.flow/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/17.oauth/02.problem.flow/app/utils/misc.tsx
+++ b/exercises/17.oauth/02.problem.flow/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/17.oauth/02.solution.flow/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/17.oauth/02.solution.flow/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/17.oauth/02.solution.flow/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/17.oauth/02.solution.flow/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/17.oauth/02.solution.flow/app/utils/misc.tsx
+++ b/exercises/17.oauth/02.solution.flow/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/17.oauth/03.problem.mock/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/17.oauth/03.problem.mock/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/17.oauth/03.problem.mock/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/17.oauth/03.problem.mock/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/17.oauth/03.problem.mock/app/utils/misc.tsx
+++ b/exercises/17.oauth/03.problem.mock/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/17.oauth/03.solution.mock/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/17.oauth/03.solution.mock/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/17.oauth/03.solution.mock/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/17.oauth/03.solution.mock/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/17.oauth/03.solution.mock/app/utils/misc.tsx
+++ b/exercises/17.oauth/03.solution.mock/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/17.oauth/04.problem.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/17.oauth/04.problem.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/17.oauth/04.problem.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/17.oauth/04.problem.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/17.oauth/04.problem.schema/app/utils/misc.tsx
+++ b/exercises/17.oauth/04.problem.schema/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/17.oauth/04.solution.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/17.oauth/04.solution.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/17.oauth/04.solution.schema/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/17.oauth/04.solution.schema/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/17.oauth/04.solution.schema/app/utils/misc.tsx
+++ b/exercises/17.oauth/04.solution.schema/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/18.provider-errors/01.problem.auth-error/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/18.provider-errors/01.problem.auth-error/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/18.provider-errors/01.problem.auth-error/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/18.provider-errors/01.problem.auth-error/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/18.provider-errors/01.problem.auth-error/app/utils/misc.tsx
+++ b/exercises/18.provider-errors/01.problem.auth-error/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/18.provider-errors/01.solution.auth-error/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/18.provider-errors/01.solution.auth-error/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/18.provider-errors/01.solution.auth-error/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/18.provider-errors/01.solution.auth-error/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/18.provider-errors/01.solution.auth-error/app/utils/misc.tsx
+++ b/exercises/18.provider-errors/01.solution.auth-error/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/18.provider-errors/02.problem.connection-error/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/18.provider-errors/02.problem.connection-error/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/18.provider-errors/02.problem.connection-error/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/18.provider-errors/02.problem.connection-error/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/18.provider-errors/02.problem.connection-error/app/utils/misc.tsx
+++ b/exercises/18.provider-errors/02.problem.connection-error/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/18.provider-errors/02.solution.connection-error/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/18.provider-errors/02.solution.connection-error/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/18.provider-errors/02.solution.connection-error/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/18.provider-errors/02.solution.connection-error/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/18.provider-errors/02.solution.connection-error/app/utils/misc.tsx
+++ b/exercises/18.provider-errors/02.solution.connection-error/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/19.third-party-login/01.problem.login/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/19.third-party-login/01.problem.login/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/19.third-party-login/01.problem.login/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/19.third-party-login/01.problem.login/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/19.third-party-login/01.problem.login/app/utils/misc.tsx
+++ b/exercises/19.third-party-login/01.problem.login/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/19.third-party-login/01.solution.login/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/19.third-party-login/01.solution.login/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/19.third-party-login/01.solution.login/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/19.third-party-login/01.solution.login/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/19.third-party-login/01.solution.login/app/utils/misc.tsx
+++ b/exercises/19.third-party-login/01.solution.login/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/19.third-party-login/02.problem.onboarding/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/19.third-party-login/02.problem.onboarding/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/19.third-party-login/02.problem.onboarding/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/19.third-party-login/02.problem.onboarding/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/19.third-party-login/02.problem.onboarding/app/utils/misc.tsx
+++ b/exercises/19.third-party-login/02.problem.onboarding/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/19.third-party-login/02.solution.onboarding/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/19.third-party-login/02.solution.onboarding/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/19.third-party-login/02.solution.onboarding/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/19.third-party-login/02.solution.onboarding/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/19.third-party-login/02.solution.onboarding/app/utils/misc.tsx
+++ b/exercises/19.third-party-login/02.solution.onboarding/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/20.connection/01.problem.existing-user/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/20.connection/01.problem.existing-user/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/20.connection/01.problem.existing-user/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/20.connection/01.problem.existing-user/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/20.connection/01.problem.existing-user/app/utils/misc.tsx
+++ b/exercises/20.connection/01.problem.existing-user/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/20.connection/01.solution.existing-user/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/20.connection/01.solution.existing-user/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/20.connection/01.solution.existing-user/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/20.connection/01.solution.existing-user/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/20.connection/01.solution.existing-user/app/utils/misc.tsx
+++ b/exercises/20.connection/01.solution.existing-user/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/20.connection/02.problem.connect/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/20.connection/02.problem.connect/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/20.connection/02.problem.connect/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/20.connection/02.problem.connect/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/20.connection/02.problem.connect/app/utils/misc.tsx
+++ b/exercises/20.connection/02.problem.connect/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/20.connection/02.solution.connect/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/20.connection/02.solution.connect/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/20.connection/02.solution.connect/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/20.connection/02.solution.connect/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/20.connection/02.solution.connect/app/utils/misc.tsx
+++ b/exercises/20.connection/02.solution.connect/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/21.redirect-cookie/01.problem.pass/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/21.redirect-cookie/01.problem.pass/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/21.redirect-cookie/01.problem.pass/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/21.redirect-cookie/01.problem.pass/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/21.redirect-cookie/01.problem.pass/app/utils/misc.tsx
+++ b/exercises/21.redirect-cookie/01.problem.pass/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/21.redirect-cookie/01.solution.pass/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/21.redirect-cookie/01.solution.pass/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/21.redirect-cookie/01.solution.pass/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/21.redirect-cookie/01.solution.pass/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/21.redirect-cookie/01.solution.pass/app/utils/misc.tsx
+++ b/exercises/21.redirect-cookie/01.solution.pass/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/21.redirect-cookie/02.problem.cookie/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/21.redirect-cookie/02.problem.cookie/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/21.redirect-cookie/02.problem.cookie/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/21.redirect-cookie/02.problem.cookie/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/21.redirect-cookie/02.problem.cookie/app/utils/misc.tsx
+++ b/exercises/21.redirect-cookie/02.problem.cookie/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/21.redirect-cookie/02.solution.cookie/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/21.redirect-cookie/02.solution.cookie/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/21.redirect-cookie/02.solution.cookie/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/21.redirect-cookie/02.solution.cookie/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/21.redirect-cookie/02.solution.cookie/app/utils/misc.tsx
+++ b/exercises/21.redirect-cookie/02.solution.cookie/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/21.redirect-cookie/03.problem.redirect/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/21.redirect-cookie/03.problem.redirect/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/21.redirect-cookie/03.problem.redirect/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/21.redirect-cookie/03.problem.redirect/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/21.redirect-cookie/03.problem.redirect/app/utils/misc.tsx
+++ b/exercises/21.redirect-cookie/03.problem.redirect/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback

--- a/exercises/21.redirect-cookie/03.solution.redirect/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/21.redirect-cookie/03.solution.redirect/app/routes/resources+/user-images.$imageId.tsx
@@ -1,9 +1,32 @@
+import path from 'node:path'
+import { readFile } from 'node:fs/promises'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'
 
+const fallbackImageId = 'fallback'
+const fallbackImagePath = path.resolve(
+	process.cwd(),
+	'app',
+	'assets',
+	'user.png',
+)
+
 export async function loader({ params }: LoaderFunctionArgs) {
 	invariantResponse(params.imageId, 'Image ID is required', { status: 400 })
+
+	if (params.imageId === fallbackImageId) {
+		const blob = await readFile(fallbackImagePath)
+		return new Response(blob, {
+			headers: {
+				'content-type': 'image/png',
+				'content-length': blob.length.toString(),
+				'content-disposition': 'inline; filename="user.png"',
+				'cache-control': 'public, max-age=31536000, immutable',
+			},
+		})
+	}
+
 	const image = await prisma.userImage.findUnique({
 		where: { id: params.imageId },
 		select: { contentType: true, blob: true },

--- a/exercises/21.redirect-cookie/03.solution.redirect/app/routes/resources+/user-images.$imageId.tsx
+++ b/exercises/21.redirect-cookie/03.solution.redirect/app/routes/resources+/user-images.$imageId.tsx
@@ -1,5 +1,5 @@
-import path from 'node:path'
 import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import { type LoaderFunctionArgs } from '@remix-run/node'
 import { prisma } from '#app/utils/db.server.ts'
 import { invariantResponse } from '#app/utils/misc.tsx'

--- a/exercises/21.redirect-cookie/03.solution.redirect/app/utils/misc.tsx
+++ b/exercises/21.redirect-cookie/03.solution.redirect/app/utils/misc.tsx
@@ -3,7 +3,7 @@ import { clsx, type ClassValue } from 'clsx'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useSpinDelay } from 'spin-delay'
 import { twMerge } from 'tailwind-merge'
-import userFallback from '#app/assets/user.png'
+const userFallback = '/resources/user-images/fallback'
 
 export function getUserImgSrc(imageId?: string | null) {
 	return imageId ? `/resources/user-images/${imageId}` : userFallback


### PR DESCRIPTION
Fixes "Unknown file extension '.png'" for fallback user images by serving them via a resource route.

The direct import of `.png` assets was causing build issues. By serving the fallback image through a dedicated resource route (`/resources/user-images/fallback`), the image is now read and served as a standard image response, resolving the build error. This change has been applied across all exercises.

---
<a href="https://cursor.com/background-agent?bcId=bc-01cd5439-4868-4a6a-9d84-c6231c69a648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-01cd5439-4868-4a6a-9d84-c6231c69a648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resolves build issues from importing `.png` assets by routing the fallback image through Remix.
> 
> - Add `resources+/user-images.$imageId.tsx` loader that returns DB-stored images and a special `fallback` case reading `app/assets/user.png` with proper headers (`content-type`, `content-length`, `content-disposition`, `cache-control`)
> - Change `getUserImgSrc` to use `'/resources/user-images/fallback'` instead of importing the PNG
> - Apply the route and util change across all exercises (problem and solution variants)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 413de22b50b1a5a59192a55cae96fb728a8eedbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->